### PR TITLE
Using Mootools anf Highcharts

### DIFF
--- a/Twig/HighchartsExtension.php
+++ b/Twig/HighchartsExtension.php
@@ -12,9 +12,9 @@ class HighchartsExtension extends \Twig_Extension
         );
     }
 
-    public function chart($chart)
+    public function chart($chart,$engine)
     {
-        return $chart->render();
+        return $chart->render($engine);
     }
 
     public function getName()


### PR DESCRIPTION
The default jQuery library is used. With this i can call Mootools instead.

``` php
public function chart($chart,$engine)
    {
        return $chart->render($engine);
    }
```

``` twig
{{ chart(chart,"mootools") }}
```

Don't forget to add the highcharts mootools adapteur.

_Don't find an other way exept modifiying render function._
