### PR TITLE
Date is not a recognised tag. Replaced it with "@since"

### DIFF
--- a/Highcharts/ChartOption.php
+++ b/Highcharts/ChartOption.php
@@ -7,7 +7,7 @@ namespace Ob\HighchartsBundle\Highcharts;
  * See Highcharts documentation at http://www.highcharts.com/ref/#chart
  *
  * @author  Marc Aubé
- * @date    2012-08-07
+ * @since   2012-08-07
  */
 class ChartOption {
 

--- a/Highcharts/Highchart.php
+++ b/Highcharts/Highchart.php
@@ -9,7 +9,7 @@ use Zend\Json\Json;
  * See Highcharts documentation at http://www.highcharts.com/ref/
  *
  * @author  Marc Aubé
- * @date    2012-08-07
+ * @since   2012-08-07
  */
 class Highchart {
 


### PR DESCRIPTION
I've noticed that the "@date" tag in the source code is breaking jms serializer as it is not a recognized docblock tag. Replaced it with "@since" and is now working as expected.

To reproduce the error: Simply try to serialize any data generated with `Highchart` class.
