### PR TITLE
Overload isset in ChartOption in order to work along with get and set overloaded methods

### DIFF
--- a/Highcharts/ChartOption.php
+++ b/Highcharts/ChartOption.php
@@ -45,4 +45,16 @@ class ChartOption
 
         return $value;
     }
+
+    /**
+     * @param string $name
+     *
+     * @return mixed
+     */
+    public function __isset($name)
+    {
+        $option_name = $this->option_name;
+        
+        return isset($this->{$option_name}->{$name});
+    }
 }


### PR DESCRIPTION
I overload the isset() method for ChartOption.php class
The get() method overloading in the same class was causing an issue in variable name declaration for javascript at Highchart.php class.

line 24: $chartJS .= "\n    var " . (isset($this->chart->renderTo) ? $this->chart->renderTo : 'chart') . " = new Highcharts.Chart({\n";
