### PR TITLE
Fix Symfony 3.1 deprecation

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,6 +3,6 @@ parameters:
 
 services:
   ob_highcharts.twig.highcharts_extension:
-    class: %ob_highcharts.twig_extension.class%
+    class: "%ob_highcharts.twig_extension.class%"
     tags:
         - { name: twig.extension }


### PR DESCRIPTION
 "Not quoting a scalar starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0. "