### PR TITLE
Able to use special (e.g "-") in renderTo

### DIFF
--- a/Highcharts/Highchart.php
+++ b/Highcharts/Highchart.php
@@ -32,7 +32,7 @@ class Highchart extends AbstractChart implements ChartInterface
         $chartJS = "";
         $chartJS .= $this->renderEngine($engine);
         $chartJS .= $this->renderOptions();
-        $chartJS .= "\n    var " . (isset($this->chart->renderTo) ? $this->chart->renderTo : 'chart') . " = new Highcharts.Chart({\n";
+        $chartJS .= "\n    var " . (isset($this->chart->renderTo) ? preg_replace('/[\W]/', "_", $this->chart->renderTo) : 'chart') . " = new Highcharts.Chart({\n";
 
         // Chart
         $chartJS .= $this->renderWithJavascriptCallback($this->chart->chart, "chart");

--- a/Highcharts/Highchart.php
+++ b/Highcharts/Highchart.php
@@ -121,8 +121,8 @@ class Highchart extends AbstractChart implements ChartInterface
      */
     private function renderPane()
     {
-        if (get_object_vars($this->pane->pane)) {
-            return "pane: " . json_encode($this->pane->pane) . ",\n";
+        if (gettype($this->pane) === 'array' || gettype($this->pane) === 'object') {
+            return $this->renderWithJavascriptCallback($this->pane, "pane");
         }
 
         return "";


### PR DESCRIPTION
Sometimes we have dynamic containers which isn't possible to change the ids.

javascript render before :
`...
var my-chart-container =
...` (which throw java script error)

After
`var my_chart_container`