### PR TITLE
Support Twig3, Symfony5 and Laminas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,25 +17,16 @@ matrix:
     fast_finish: true
     include:
           # Test with lowest dependencies
-        - php: 7.1
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak"
-        - php: 5.5
+        - php: 7.2
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak"
 
           # Test the latest stable release
-        - php: hhvm
-        - php: 5.5
-        - php: 5.6
-        - php: 7.0
-        - php: 7.1
         - php: 7.2
           env: COVERAGE=true TEST_COMMAND="./vendor/bin/simple-phpunit --coverage-text --coverage-clover=coverage.clover"
+        - php: 7.3
+        - php: 7.4
 
           # Force some major versions of Symfony
-        - php: 7.2
-          env: DEPENDENCIES="dunglas/symfony-lock:^2"
-        - php: 7.2
-          env: DEPENDENCIES="dunglas/symfony-lock:^3"
         - php: 7.2
           env: DEPENDENCIES="dunglas/symfony-lock:^4"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 ## [Unreleased]
 
-TBD
+* Added support for Symfony 5
+* Added support for Twig 3
 
 
 ### [1.6.0] - 2017-12-27

--- a/Highcharts/AbstractChart.php
+++ b/Highcharts/AbstractChart.php
@@ -2,7 +2,7 @@
 
 namespace Ob\HighchartsBundle\Highcharts;
 
-use Zend\Json\Json;
+use Laminas\Json\Json;
 
 abstract class AbstractChart
 {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ObHighchartsBundle
 
-`ObHighchartsBundle` eases the use of highcharts to display rich graphs and charts in your Symfony2 application by
+`ObHighchartsBundle` eases the use of highcharts to display rich graphs and charts in your Symfony application by
 providing Twig extensions and PHP objects to do the heavy lifting. The bundle uses the excellent JS library
 [Highcharts](http://www.highcharts.com).
 

--- a/Tests/Highcharts/ScrollbarTest.php
+++ b/Tests/Highcharts/ScrollbarTest.php
@@ -23,7 +23,7 @@ class ScrollbarTest extends TestCase
     /**
      * Initialises the data
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->scrollbar = array(
             'enabled' => true,

--- a/Tests/Highcharts/SeriesTest.php
+++ b/Tests/Highcharts/SeriesTest.php
@@ -18,7 +18,7 @@ class SeriesTest extends TestCase
     /**
      * Initialises the data
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->series = array(
             array("name" => "Data Serie #1", "data" => array(1,2,4,5,6,3,8)),

--- a/Tests/Highstock/ChartTest.php
+++ b/Tests/Highstock/ChartTest.php
@@ -9,7 +9,7 @@ class ChartTest extends TestCase
 {
     protected $chart;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->chart = new Highstock();
     }

--- a/Tests/Highstock/CreditsTest.php
+++ b/Tests/Highstock/CreditsTest.php
@@ -10,7 +10,7 @@ class CreditsTest extends TestCase
     protected $chart;
     protected $credits;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->chart = new Highstock();
         $this->credits = $this->chart->credits;

--- a/Tests/Highstock/RangeSelectorTest.php
+++ b/Tests/Highstock/RangeSelectorTest.php
@@ -10,7 +10,7 @@ class RangeSelectorTest extends TestCase
     protected $chart;
     protected $range;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->chart = new Highstock();
         $this->range = $this->chart->rangeSelector;

--- a/Twig/HighchartsExtension.php
+++ b/Twig/HighchartsExtension.php
@@ -2,13 +2,15 @@
 namespace Ob\HighchartsBundle\Twig;
 
 use Ob\HighchartsBundle\Highcharts\ChartInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class HighchartsExtension extends \Twig_Extension
+class HighchartsExtension extends AbstractExtension
 {
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('chart', array($this, 'chart'), array('is_safe' => array('html'))),
+            new TwigFunction('chart', array($this, 'chart'), array('is_safe' => array('html'))),
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "ob/highcharts-bundle",
     "type": "symfony-bundle",
-    "description": "Symfony2 Bundle that ease the use of highcharts to display rich graph and charts in your app",
-    "keywords": ["symfony2", "charting", "charts", "highcharts", "chart", "graph", "graphs", "ob", "marcaube"],
+    "description": "Symfony Bundle that ease the use of highcharts to display rich graph and charts in your app",
+    "keywords": ["symfony", "charting", "charts", "highcharts", "chart", "graph", "graphs", "ob", "marcaube"],
     "homepage": "https://github.com/marcaube/ObHighchartsBundle",
     "license": "MIT",
     "authors": [
@@ -12,18 +12,18 @@
     ],
 
     "require": {
-        "php": "^5.5 || ^7.0",
-        "symfony/http-kernel": "^2.8 || ^3.4 || ^4.0",
-        "symfony/dependency-injection": "^2.8 || ^3.4 || ^4.0",
-        "symfony/config": "^2.8 || ^3.4 || ^4.0",
-        "symfony/yaml": "^2.8 || ^3.4 || ^4.0",
-        "zendframework/zend-json": "^2.3 || ^3.0",
-        "twig/twig": "^1.35 || ^2.4"
+        "php": "^7.2",
+        "symfony/http-kernel": "^4.4 || ^5.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0",
+        "symfony/config": "^4.4 || ^5.0",
+        "symfony/yaml": "^4.4 || ^5.0",
+        "twig/twig": "^2.10 || ^3.0",
+        "laminas/laminas-json": "^3.1"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^3.3 || ^4.0",
-        "symfony/framework-bundle": "^2.8 || ^3.4 || ^4.0",
-        "nyholm/symfony-bundle-test": "^1.2.3"
+        "symfony/phpunit-bridge": "^4.4 || ^5.0",
+        "symfony/framework-bundle": "^4.4 || ^5.0",
+        "nyholm/symfony-bundle-test": "^1.6.1"
     },
     "autoload": {
         "psr-4": { "Ob\\HighchartsBundle\\": "" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,8 +10,11 @@
         convertWarningsToExceptions = "true"
         processIsolation            = "false"
         stopOnFailure               = "false"
-        syntaxCheck                 = "false"
         bootstrap                   = "vendor/autoload.php">
+
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[indirect]=1" />
+    </php>
 
     <testsuites>
         <testsuite name="Test Suite">


### PR DESCRIPTION
This PR adds support for Symfony 5 and Twig 3. 

It will replace both  #106 & #108. 

It is safe to release in 1.7. 

